### PR TITLE
SLSPSporoPay always requires amount in format of two decimal places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.20.1: 2020/08/13
+
+Always format SLSPSporoPay amount to two decimal places.
+
 ### v0.20.0: 2020/07/27
 
 Added support for ePlatby VÚB sandbox.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simple and unified object-oriented library written in PHP for e-commerce service
 
 * [PayPal](http://www.paypal.com) -- PayPal (Europe) S.à r.l. et Cie, S.C.A.
 
-The current version of the library is v0.20.0 and requires PHP 5.4 or PHP 7+ to work. Even though there are things to make better, it is already being used in production without any sort of problems.
+The current version of the library is v0.20.1 and requires PHP 5.4 or PHP 7+ to work. Even though there are things to make better, it is already being used in production without any sort of problems.
 
 Chaching library is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).
 
@@ -28,7 +28,7 @@ The recommended way to install the library is to use [composer](http://getcompos
 
 	{
 	  "require": {
-	    "backbone/chaching": "0.20.0"
+	    "backbone/chaching": "0.20.1"
 	  }
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "backbone/chaching",
     "type": "library",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "license": "MIT",
     "description": "Universal payment library for banking services in Slovakia",
     "keywords": [

--- a/src/Chaching/Chaching.php
+++ b/src/Chaching/Chaching.php
@@ -16,7 +16,7 @@ use \Chaching\Exceptions\InvalidOptionsException;
 
 class Chaching
 {
-	const VERSION 		= '0.20.0';
+	const VERSION 		= '0.20.1';
 
 	const CARDPAY 		= 'cardpay';
 	const SPOROPAY 		= 'sporopay';

--- a/src/Chaching/Drivers/SLSPSporoPay/Request.php
+++ b/src/Chaching/Drivers/SLSPSporoPay/Request.php
@@ -117,10 +117,7 @@ class Request extends \Chaching\Message
 		// Validate all required fields first
 		$this->validate_required_fields();
 
-		if (!is_string($this->fields['suma']))
-		{
-			$this->fields['suma'] = sprintf('%01.2F', $this->fields['suma']);
-		}
+		$this->fields['suma'] = sprintf('%01.2F', $this->fields['suma']);
 
 		if (!preg_match('/^[0-9]{1,13}(\.[0-9]{1,2})?$/', $this->fields['suma']))
 			throw new InvalidOptionsException(sprintf(


### PR DESCRIPTION
SLSPSporoPay requires always to have paymant amount in form of two decimal places. If amount is whole number and is received as `int` data type, the sprintf is not executed and payment request is not successful.