### PR TITLE
Fix of TB CardPay MID validation

### DIFF
--- a/src/Chaching/Drivers/TBCardPay/Request.php
+++ b/src/Chaching/Drivers/TBCardPay/Request.php
@@ -124,7 +124,7 @@ class Request extends \Chaching\Message
 			? $this->auth[ 0 ]
 			: '';
 
-		if (!preg_match('/^[a-z0-9]{3,4}$/', $this->fields['MID']))
+		if (!preg_match('/^[a-z0-9]{3,5}$/', $this->fields['MID']))
 			throw new InvalidOptionsException(sprintf(
 				"Authorization information (Merchant ID or MID) has an " .
 				"unacceptable value '%s'. Try changing it to value you " .


### PR DESCRIPTION
Now they are using 5 digits.