### PR TITLE
Remove TBTatraPay, TBCardPay MID length checks

### DIFF
--- a/src/Chaching/Drivers/TBCardPay/Refund.php
+++ b/src/Chaching/Drivers/TBCardPay/Refund.php
@@ -89,13 +89,6 @@ class Refund extends \Chaching\Message implements \Chaching\ECDSAResponseInterfa
 			? $this->auth[ 0 ]
 			: '';
 
-		if (!preg_match('/^[a-z0-9]{3,4}$/', $this->fields['MID']))
-			throw new InvalidOptionsException(sprintf(
-				"Authorization information (Merchant ID or MID) has an " .
-				"unacceptable value '%s'. Try changing it to value you " .
-				"got from the bank.", $this->fields['MID']
-			));
-
 		if (!isset($this->auth[ 1 ]) OR empty($this->auth[ 1 ]))
 			throw new InvalidOptionsException(
 				"Authorization information are unacceptable as it does " .

--- a/src/Chaching/Drivers/TBCardPay/Request.php
+++ b/src/Chaching/Drivers/TBCardPay/Request.php
@@ -124,13 +124,6 @@ class Request extends \Chaching\Message
 			? $this->auth[ 0 ]
 			: '';
 
-		if (!preg_match('/^[a-z0-9]{3,5}$/', $this->fields['MID']))
-			throw new InvalidOptionsException(sprintf(
-				"Authorization information (Merchant ID or MID) has an " .
-				"unacceptable value '%s'. Try changing it to value you " .
-				"got from the bank.", $this->fields['MID']
-			));
-
 		if (!isset($this->auth[ 1 ]) OR empty($this->auth[ 1 ]))
 			throw new InvalidOptionsException(
 				"Authorization information are unacceptable as it does " .

--- a/src/Chaching/Drivers/TBTatraPay/Request.php
+++ b/src/Chaching/Drivers/TBTatraPay/Request.php
@@ -96,13 +96,6 @@ class Request extends \Chaching\Message
 			? $this->auth[ 0 ]
 			: '';
 
-		if (!preg_match('/^[a-z0-9]{3,5}$/', $this->fields['MID']))
-			throw new InvalidOptionsException(sprintf(
-				"Authorization information (Merchant ID or MID) has an " .
-				"unacceptable value '%s'. Try changing it to value you " .
-				"got from the bank.", $this->fields['MID']
-			));
-
 		if (!isset($this->auth[ 1 ]) OR empty($this->auth[ 1 ]))
 			throw new InvalidOptionsException(
 				"Authorization information are unacceptable as it does " .

--- a/src/Chaching/Drivers/TBTatraPay/Status.php
+++ b/src/Chaching/Drivers/TBTatraPay/Status.php
@@ -65,13 +65,6 @@ class Status extends \Chaching\Message
 			? $this->auth[ 0 ]
 			: '';
 
-		if (!preg_match('/^[a-z0-9]{3,4}$/', $this->fields['MID']))
-			throw new InvalidOptionsException(sprintf(
-				"Authorization information (Merchant ID or MID) has an " .
-				"unacceptable value '%s'. Try changing it to value you " .
-				"got from the bank.", $this->fields['MID']
-			));
-
 		if (!isset($this->auth[ 1 ]) OR empty($this->auth[ 1 ]))
 			throw new InvalidOptionsException(
 				"Authorization information are unacceptable as it does " .


### PR DESCRIPTION
We noticed that recently TatraBank started to give 5 digit long Merchant IDs and therefore this library no longer generated the redirects to the payment pages. The latest release still expects it to be 3 or 4 character long MID. There's no proper release with a fix for this problem but these similar pull requests were committed to master already:
- https://github.com/backbonesk/chaching/pull/10
- https://github.com/backbonesk/chaching/pull/11

But this MID length check is also done in the Refund code which still expects 3 or 4 character long MID.

After a few hours of confusion, I think the best would be removing these string length checks completely. If someone sets the MID wrong, then the bank's payment page will not display due to invalid parameters, so people will notice that there's something wrong. I don't see the point of these checks. Also, it can happen in the future that TB will change the format of the MIDs again and again, and this confusion will start again.

I attach a possible fix with removing these unnecessary checks.