### PR TITLE
PHP 8 compatibility fix for deprecated openssl_free_key() calls

### DIFF
--- a/src/Chaching/Encryption/PemKeys.php
+++ b/src/Chaching/Encryption/PemKeys.php
@@ -27,7 +27,10 @@ class PemKeys extends \Chaching\Encryption
 
 		$signature = base64_encode($signature);
 
-		openssl_free_key($resource_id);
+    // PHP 8 deprecates openssl_free_key (actually openssl_pkey_free which it aliases) and automatically destroys the key instance when it goes out of scope.
+    if (PHP_VERSION_ID < 80000) {
+      openssl_free_key($resource_id);
+    }
 
 		return $signature;
 	}
@@ -41,7 +44,10 @@ class PemKeys extends \Chaching\Encryption
 		$given_signature = base64_decode($given_signature);
 		$result = openssl_verify($signature_base, $given_signature, $resource_id);
 
-		openssl_free_key($resource_id);
+    // PHP 8 deprecates openssl_free_key (actually openssl_pkey_free which it aliases) and automatically destroys the key instance when it goes out of scope.
+    if (PHP_VERSION_ID < 80000) {
+      openssl_free_key($resource_id);
+    }
 
 		return (bool) ($result === 1);
 	}


### PR DESCRIPTION
GpWebPay's sign() method uses the openssl_free_key() function that is deprecated starting from PHP 8 and later. Remove that or if we want to remain compatible with PHP 7, then add a condition based on the current PHP version. In the PR I chose to do the later one.